### PR TITLE
Add Firestore migration scripts and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+serviceAccountKey.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# N
+# Firestore Migration Example
+
+This repository contains scripts and configuration for migrating driver and pickup point data from Google Sheets to Firestore and fetching the data directly from Firestore in a client app.
+
+## Migrate Google Sheet to Firestore
+
+Run the script:
+
+```bash
+SHEET_ID=<sheet-id> \
+GOOGLE_APPLICATION_CREDENTIALS=serviceAccountKey.json \
+node scripts/migrateSheetToFirestore.js
+```
+
+The script expects two sheets named `Drivers` and `PickupPoints` with columns:
+
+- `Drivers`: `id`, `name`, `phone`, `address`, `status`
+- `PickupPoints`: `id`, `name`, `address`, `city`, `status`
+
+## Fetch Data in Client
+
+`src/fetchData.js` exposes a `fetchData` function that reads both collections using Firestore's `getDocs`.
+
+Set the following environment variables for Firebase configuration:
+
+- `FIREBASE_API_KEY`
+- `FIREBASE_AUTH_DOMAIN`
+- `FIREBASE_PROJECT_ID`
+
+## Security Rules and Indexes
+
+- `firestore.rules` defines basic authenticated read/write access for the new collections.
+- `firestore.indexes.json` contains sample composite indexes for common queries.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,21 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "drivers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "pickupPoints",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "city", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /drivers/{driverId} {
+      allow read, write: if request.auth != null;
+    }
+    match /pickupPoints/{pointId} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "n",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node -e \"console.log('no tests');\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "firebase": "^10.7.0",
+    "firebase-admin": "^11.10.1",
+    "googleapis": "^126.0.0",
+    "dotenv": "^16.4.0"
+  }
+}

--- a/scripts/migrateSheetToFirestore.js
+++ b/scripts/migrateSheetToFirestore.js
@@ -1,0 +1,65 @@
+/**
+ * Script to migrate data from Google Sheets to Firestore.
+ *
+ * Usage: set environment variables SHEET_ID and GOOGLE_APPLICATION_CREDENTIALS.
+ * Optionally DRIVER_RANGE and PICKUP_RANGE for the sheet ranges.
+ */
+
+const { google } = require('googleapis');
+const admin = require('firebase-admin');
+require('dotenv').config();
+
+const sheetId = process.env.SHEET_ID;
+const driverRange = process.env.DRIVER_RANGE || 'Drivers!A2:E';
+const pickupRange = process.env.PICKUP_RANGE || 'PickupPoints!A2:E';
+
+if (!sheetId) {
+  console.error('Missing SHEET_ID environment variable');
+  process.exit(1);
+}
+
+admin.initializeApp({
+  credential: admin.credential.cert(require(process.env.GOOGLE_APPLICATION_CREDENTIALS)),
+});
+
+const firestore = admin.firestore();
+
+async function loadSheet(range) {
+  const auth = new google.auth.GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+  });
+  const sheets = google.sheets({ version: 'v4', auth: await auth.getClient() });
+  const res = await sheets.spreadsheets.values.get({ spreadsheetId: sheetId, range });
+  return res.data.values || [];
+}
+
+function rowToDoc(row, fields) {
+  const doc = {};
+  fields.forEach((f, i) => {
+    doc[f] = row[i];
+  });
+  return doc;
+}
+
+async function migrate() {
+  const driverRows = await loadSheet(driverRange);
+  const driverFields = ['id', 'name', 'phone', 'address', 'status'];
+  for (const row of driverRows) {
+    const doc = rowToDoc(row, driverFields);
+    await firestore.collection('drivers').doc(doc.id).set(doc);
+  }
+
+  const pickupRows = await loadSheet(pickupRange);
+  const pickupFields = ['id', 'name', 'address', 'city', 'status'];
+  for (const row of pickupRows) {
+    const doc = rowToDoc(row, pickupFields);
+    await firestore.collection('pickupPoints').doc(doc.id).set(doc);
+  }
+
+  console.log('Migration complete');
+}
+
+migrate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/fetchData.js
+++ b/src/fetchData.js
@@ -1,0 +1,21 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore, collection, getDocs } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+export async function fetchData() {
+  const driversSnap = await getDocs(collection(db, 'drivers'));
+  const pickupSnap = await getDocs(collection(db, 'pickupPoints'));
+
+  const drivers = driversSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  const pickupPoints = pickupSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+
+  return { drivers, pickupPoints };
+}


### PR DESCRIPTION
## Summary
- add Node script to migrate data from Google Sheets to Firestore
- implement fetchData using Firestore getDocs
- include security rules and sample indexes for drivers and pickupPoints collections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1de961794833397a22a777fd21790